### PR TITLE
fix: handle special characters in paths

### DIFF
--- a/lib/getDependencies.js
+++ b/lib/getDependencies.js
@@ -69,7 +69,7 @@ function isRelevantModule(modulePath, rootModulesPath, excludedModules) {
 }
 
 function isPackageDependency(modulePath, rootModulesPath) {
-  return modulePath.search(rootModulesPath) > -1;
+  return modulePath.indexOf(rootModulesPath) > -1;
 }
 
 function isExcluded(modulePath, excludedModules) {


### PR DESCRIPTION
The `search()` method implicitly converts the search string into a Regular Expression. If the project path contains special RegEx characters (such as `+` in version strings like `0+git` or `.` in folder names), the match fails incorrectly, resulting in zero files being copied.